### PR TITLE
Fix merging of placeholder options

### DIFF
--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -28,7 +28,7 @@ const defaultOptions: PlaceholderOptions = {
 };
 
 export async function generatePlaceholder(src: string, options: PlaceholderOptions = defaultOptions): Promise<PlaceholderResult> {
-	options = Object.assign(options, defaultOptions);
+	options = Object.assign({}, defaultOptions, options);
 
 	// Ensure the outputDir has an ending slash, otherwise files would get generated in the wrong folder
 	options.outputDir = options.outputDir.endsWith('/') ? options.outputDir : options.outputDir + '/';


### PR DESCRIPTION
Hi!

Thanks for this useful package.

I noticed that custom placeholder options were not applied (I tried passing `{ outputDir: "src/assets/placeholders/showcase" }`, which did not work).

To fix this, the order of custom and default options have to be flipped for `Object.assign`, so that the custom ones take precedence.